### PR TITLE
Update buildpack to latest base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_IMAGE_NAME:latest $DOCKER_IMAGE_NAME:$TRAVIS_TAG; fi && docker push $DOCKER_IMAGE_NAME
 
 env:
-  - DOCKER_IMAGE_NAME=particle/buildpack-hal
+  - DOCKER_IMAGE_NAME=digistump/buildpack-oak
 notifications:
   slack:
     secure: VJ+tAeUzLkz4aMAshQ9ohXZb/1+DQ31kDpcZYDS5PZuXOujx57rzOBg4SKxB2awcmNS2JWlSMQRQtNUzfS15YNuLqgWVj57EQAy99QKsEvccOMELIwbpLtEyEInK5WrUk6vk9ymhk6MBT5+3JiQ4bAs5yvIxm+k8YCakV9QlnH4=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM particle/buildpack-wiring-preprocessor:0.0.3
+FROM particle/buildpack-base:0.3.6
 
+ARG OAK_CORE_VERSION
 # Get required packages to download the Oak libraries
 RUN apt-get update && \
-    apt-get -y install wget unzip
+    apt-get -y install wget unzip python make
 
-# Install OakCore libraries - note that this points to 
+# Install OakCore libraries - note that this points to
 # the latest "source code" zip release
-RUN wget -O /oakCore.zip https://github.com/digistump/OakCore/archive/0.9.4.zip && \
+RUN wget -O /oakCore.zip https://github.com/digistump/OakCore/archive/${OAK_CORE_VERSION}.zip && \
     unzip oakCore.zip && \
-    mv /OakCore-0.9.4 /oakCore 
+    mv /OakCore-${OAK_CORE_VERSION} /oakCore
 
 # Setup tools required for building
 # (Done now to speed up processing time later)
 RUN cd /oakCore/tools && \
     python get.py
 
-COPY hooks /hooks
+COPY bin /bin
 COPY makefile /oakCore/makefile

--- a/README.md
+++ b/README.md
@@ -1,26 +1,24 @@
-# Buildpack for HAL firmware
-Buildpack for modern (HAL based) Particle firmware.
+# Buildpack for Oak devices
+Buildpack for Oak devices using Particle.
 
-[![Build Status](https://travis-ci.org/spark/buildpack-hal.svg)](https://travis-ci.org/spark/buildpack-hal)
+[![Build Status](https://travis-ci.org/digistump/buildpack-oak.svg)](https://travis-ci.org/digistump/buildpack-oak)
 
 | |
 |---|
-|  [Particle firmware](https://github.com/spark/firmware-buildpack-builder)  |
-| **HAL (you are here)** / [Legacy](https://github.com/spark/buildpack-0.3.x)   |
-| [Wiring preprocessor](https://github.com/spark/buildpack-wiring-preprocessor) |
+| **Oak (you are here)**    |
 | [Base](https://github.com/spark/buildpack-base) |
 
-This image inherits [Wiring preprocessor](https://github.com/spark/buildpack-wiring-preprocessor) and calls [`preprocess-ino` function](https://github.com/spark/buildpack-wiring-preprocessor#running) before doing build.
+This image inherits [base buildpack](https://github.com/spark/buildpack-base).
 
 ## Building image
 
-**Before building this image, build or pull [buildpack-wiring-preprocessor](https://github.com/spark/buildpack-wiring-preprocessor).**
+**Before building this image, build or pull [buildpack-base](https://github.com/spark/buildpack-base).**
 
 ```bash
-$ export BUILDPACK_IMAGE=hal
-$ git clone "git@github.com:spark/buildpack-${BUILDPACK_IMAGE}.git"
+$ export BUILDPACK_IMAGE=oak
+$ git clone "git@github.com:digistump/buildpack-${BUILDPACK_IMAGE}.git"
 $ cd buildpack-$BUILDPACK_IMAGE
-$ docker build -t particle/buildpack-$BUILDPACK_IMAGE .
+$ docker build -t digistump/buildpack-$BUILDPACK_IMAGE --build-arg OAK_CORE_VERSION=1.0.2 .
 ```
 
 ## Running
@@ -28,24 +26,23 @@ $ docker build -t particle/buildpack-$BUILDPACK_IMAGE .
 ```bash
 $ mkdir -p ~/tmp/input && mkdir -p ~/tmp/output && mkdir -p ~/tmp/cache
 $ docker run --rm \
-  --privileged \
   -v ~/tmp/input:/input \
   -v ~/tmp/output:/output \
   -v ~/tmp/cache:/cache \
-  -e FIRMWARE_REPO=https://github.com/spark/firmware.git#photon_043 \
-  -e PLATFORM_ID=6
-  particle/buildpack-hal
+  -v ~/tmp/log:/log \
+  digistump/buildpack-oak
 ```
 
 ### Input files
 Source files have to be placed in `~/tmp/input`
 
 ### Output files
-After build `~/tmp/output` will be propagated with:
+If compilation succeeds `~/tmp/output` will be propagated with:
+
+* `firmware.bin` - compiled firmware
+
+### Log files
+Following logs will be placed in `~/tmp/log`:
 
 * `run.log` - `stdout` combined with `stderr`
 * `stderr.log` - contents of `stderr`, usefull to parse `gcc` errors
-
-**Files only available if compilation succeeds:**
-* `firmware.bin` - compiled firmware
-* `memory-use.log` - firmware memory use

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Copy pin details with the other source files
+cp /oakCore/variants/oak/pins_arduino.* /oakCore/cores/oak/
+
+# Build
+cd /oakCore
+make
+
+# Normalize firmware binary name
+mv `find $WORKSPACE_DIR -name '*.bin'` $OUTPUT_DIR/firmware.bin

--- a/hooks/build
+++ b/hooks/build
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cd /oakCore
-make

--- a/hooks/post-build
+++ b/hooks/post-build
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Normalize firmware binary name
-mv $OUTPUT_DIR/sketch.bin $OUTPUT_DIR/firmware.bin

--- a/hooks/post-env
+++ b/hooks/post-env
@@ -1,3 +1,0 @@
-export APPDIR=$WORKSPACE_DIR
-export FIRMWARE_HASH=`echo -n $FIRMWARE_REPO | md5sum | awk '{ print $1 }'`
-export FIRMWARE_PATH="$CACHE_DIR/$FIRMWARE_HASH/firmware"

--- a/hooks/pre-build
+++ b/hooks/pre-build
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Copy pin details with the other source files
-cp /oakCore/variants/oak/pins_arduino.* /oakCore/cores/oak/

--- a/makefile
+++ b/makefile
@@ -3,8 +3,8 @@
 #
 # A slightly modified version of makeESPArduino, which
 # is a makefile for ESP8286 Arduino projects.
-# 
-# Base file available at 
+#
+# Base file available at
 #    https://github.com/plerup/makeEspArduino
 #
 #====================================================================================
@@ -14,7 +14,7 @@
 #====================================================================================
 
 #=== Project specific definitions: sketch and list of needed libraries
-SKETCH ?= /input/sketch.ino
+SKETCH ?= $(shell find $(WORKSPACE_DIR) -name '*.ino')
 
 # Esp8266 Arduino git location
 ESP_ROOT ?= /oakCore
@@ -26,7 +26,7 @@ LIBS ?= $(ESP_LIBS)/Wire \
         $(ESP_LIBS)/ESP8266WebServer
 
 # Output directory
-BUILD_ROOT ?= /output
+BUILD_ROOT ?= $(WORKSPACE_DIR)
 
 # Board definitions
 FLASH_SIZE ?= 4M
@@ -143,7 +143,7 @@ $(MAIN_EXE): $(CORE_LIB) $(USER_OBJ)
 	echo '_tBuildInfo _BuildInfo = {"$(BUILD_DATE)","$(BUILD_TIME)"};' >>$(BUILD_INFO_CPP)
 	$(CPP) $(C_DEFINES) $(C_INCLUDES) $(CPP_FLAGS) $(BUILD_INFO_CPP) -o $(BUILD_INFO_OBJ)
 	$(LD) $(LD_FLAGS) -Wl,--start-group $^ $(BUILD_INFO_OBJ) $(LD_STD_LIBS) -Wl,--end-group -L$(OBJ_DIR) -o $(MAIN_ELF)
-	$(ESP_TOOL) -bin /output/obj/sketch.elf /output/sketch.bin .irom0.text .text .data .rodata
+	$(ESP_TOOL) -bin $(MAIN_ELF) $(MAIN_EXE) .irom0.text .text .data .rodata
 	$(TOOLS_BIN)/xtensa-lx106-elf-size -A $(MAIN_ELF) | perl -e $(MEM_USAGE)
 	perl -e 'print "Build complete. Elapsed time: ", time()-$(START_TIME),  " seconds\n\n"'
 


### PR DESCRIPTION
Original buildpack layout changed a bit and this PR updates Oak's one so it works with the new Particle infrastructure.

It's recommended to create Digistump's [Docker Hub account](https://hub.docker.com/u/digistump/) and hook up [OakCore](https://github.com/digistump/OakCore) repo with [Travis CI](http://suda.pl/build-and-push-docker-images-using-travis/) so pushing a new tag would automatically build latest Docker image.

Until then Oak's buildpack can be published with:

``` sh
$ export BUILDPACK_IMAGE=digistump/buildpack-oak
$ export OAK_CORE_VERSION=X.Y.Z
$ docker build -t $BUILDPACK_IMAGE --build-arg OAK_CORE_VERSION=$OAK_CORE_VERSION .
$ docker tag $BUILDPACK_IMAGE:latest $BUILDPACK_IMAGE:$OAK_CORE_VERSION
$ docker push $BUILDPACK_IMAGE:latest $BUILDPACK_IMAGE:$OAK_CORE_VERSION
```

Much 💗  from Particle!
