### PR TITLE
Hardcode v1.0.5 to build in Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM particle/buildpack-base:0.3.6
 
-ARG OAK_CORE_VERSION
 # Get required packages to download the Oak libraries
 RUN apt-get update && \
     apt-get -y install wget unzip python make
 
 # Install OakCore libraries - note that this points to
 # the latest "source code" zip release
-RUN wget -O /oakCore.zip https://github.com/digistump/OakCore/archive/${OAK_CORE_VERSION}.zip && \
+RUN wget -O /oakCore.zip https://github.com/digistump/OakCore/archive/1.0.5.zip && \
     unzip oakCore.zip && \
-    mv /OakCore-${OAK_CORE_VERSION} /oakCore
+    mv /OakCore-1.0.5 /oakCore
 
 # Setup tools required for building
 # (Done now to speed up processing time later)


### PR DESCRIPTION
This should allow us to build an image in the Docker hub with tag 1.0.5 (according to the docs).
Note that build args don't yet work on the Hub; I've temporarily removed that part to get it working for now but hopefully we can get that working before long :-)
