### PR TITLE
Move compilation of pre-requisites to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM particle/buildpack-base:0.3.6
+MAINTAINER Digistump LLC <support@digistump.com> 
 
 ARG OAK_CORE_VERSION
 # Get required packages to download the Oak libraries
 RUN apt-get update && \
-    apt-get -y install wget unzip python make
+    apt-get -y install wget unzip python make && \
+    apt-get clean
 
 # Install OakCore libraries - note that this points to
 # the latest "source code" zip release
@@ -11,10 +13,18 @@ RUN wget -O /oakCore.zip https://github.com/digistump/OakCore/archive/${OAK_CORE
     unzip oakCore.zip && \
     mv /OakCore-${OAK_CORE_VERSION} /oakCore
 
-# Setup tools required for building
-# (Done now to speed up processing time later)
+# Place supporting files into the right places
+COPY bin /bin
+RUN cp /oakCore/variants/oak/pins_arduino.* /oakCore/cores/oak/
+
+# Run some setup scripts now to make subsequent processing a lot faster
+
+# Setup tools required for building 
 RUN cd /oakCore/tools && \
     python get.py
 
-COPY bin /bin
+# Build pre-requsities
 COPY makefile /oakCore/makefile
+RUN cd /oakCore && \
+    . /bin/setup-env && \
+    make

--- a/bin/build
+++ b/bin/build
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-# Copy pin details with the other source files
-cp /oakCore/variants/oak/pins_arduino.* /oakCore/cores/oak/
-
 # Build
 cd /oakCore
-make
+make build
 
 # Normalize firmware binary name
 mv `find $WORKSPACE_DIR -name '*.bin'` $OUTPUT_DIR/firmware.bin

--- a/makefile
+++ b/makefile
@@ -137,15 +137,15 @@ $(CORE_LIB): $(CORE_OBJ)
 BUILD_DATE = $(call time_string,"%Y-%m-%d")
 BUILD_TIME = $(call time_string,"%H:%M:%S")
 
-$(MAIN_EXE): $(CORE_LIB) $(USER_OBJ)
+build: $(CORE_LIB) $(USER_OBJ)
 	echo Linking $(MAIN_EXE)
-	echo 	'#include <buildinfo.h>' >$(BUILD_INFO_CPP)
+	echo '#include <buildinfo.h>' >$(BUILD_INFO_CPP)
 	echo '_tBuildInfo _BuildInfo = {"$(BUILD_DATE)","$(BUILD_TIME)"};' >>$(BUILD_INFO_CPP)
 	$(CPP) $(C_DEFINES) $(C_INCLUDES) $(CPP_FLAGS) $(BUILD_INFO_CPP) -o $(BUILD_INFO_OBJ)
 	$(LD) $(LD_FLAGS) -Wl,--start-group $^ $(BUILD_INFO_OBJ) $(LD_STD_LIBS) -Wl,--end-group -L$(OBJ_DIR) -o $(MAIN_ELF)
 	$(ESP_TOOL) -bin $(MAIN_ELF) $(MAIN_EXE) .irom0.text .text .data .rodata
 	$(TOOLS_BIN)/xtensa-lx106-elf-size -A $(MAIN_ELF) | perl -e $(MEM_USAGE)
-	perl -e 'print "Build complete. Elapsed time: ", time()-$(START_TIME),  " seconds\n\n"'
+	perl -e 'print "Build complete. Elapsed time: ", time()-$(START_TIME),  " seconds\n\n"'	
 
 clean:
 	echo Removing all intermediate build files...
@@ -155,7 +155,7 @@ $(OBJ_DIR):
 	mkdir -p $(OBJ_DIR)
 
 .PHONY: all
-all: $(OBJ_DIR) $(BUILD_INFO_H) $(MAIN_EXE)
+all: $(OBJ_DIR) $(BUILD_INFO_H) $(CORE_LIB) $(USER_OBJ)
 
 
 # Include all available dependencies


### PR DESCRIPTION
This adds the compilation of all the various dependencies into the Docker build process.
Running the container now takes a lot less time... on my test it took less than a second to build my sketch!
